### PR TITLE
Update ocpp-autel.yaml

### DIFF
--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -12,6 +12,7 @@ requirements:
   description:
     de: |
       Anleitung:
+      * Wichtig! Als erstes prüfen ob auf der Wallbox mindestens fogende Firmwareversion installiert ist: Ladesteuergerät: V1.51.00 und Leistungsregelmodul: V1.19.00
       * In der Autel Charge app, klicken sie auf “OCPP Server”
       * Geben Sie "Custom" in das Feld ein und wählen Sie "Personalisierung" darunter
       * Server-URL: ws://[evcc-adresse]:8887/ (Verbindung über das lokale Netzwerk)
@@ -19,6 +20,7 @@ requirements:
       * Autorisierungsschlüssel: leer lassen
     en: |
       Setup Guide:
+      * Important! First check that at least the following firmware version is installed on the wallbox: Charge Control Module: V1.51.00 and Power Control Module: V1.19.00
       * In the Autel Charge app, click on “OCPP Server”
       * In the search bar type “Custom” and select it.
       * Server URL: ws://[evcc-address]:8887/ (local network connection)


### PR DESCRIPTION
Autel Wallbox add minimal firmware version that OCPP works. My wallbox arrived with a firmware, that don't work with evee ocpp-autel protocol.